### PR TITLE
Add R suffix for search engines to ensure R relevant results (close #10)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,10 @@
 Package: searcher
 Title: Query Search Interfaces 
-Version: 0.0.2.1000
+Version: 0.0.2.2000
 Authors@R: c(person("James", "Balamuta",
                     email = "balamut2@illinois.edu", role = c("aut", "cre")))
 Description: Provides a search interface to look up terms
-    on 'Google', 'Bing', 'DuckDuckGo', 'StackOverflow', 'GitHub', and 'BitBucket'.
+    on 'Google', 'Bing', 'ixquick', 'DuckDuckGo', 'StackOverflow', 'GitHub', and 'BitBucket'.
     Upon searching, a browser window will open with the aforementioned search
     results.
 URL: https://github.com/coatless/searcher

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,11 +2,12 @@
 
 ## Features
 
-- Added search portal `search_ixquick()`: Searches with [ixquick](https://www.ixquick.com/). (#6)
+- Added search portal `search_ixquick()`: Searches with [ixquick](https://www.ixquick.com/). (#8, #6)
 
 ## Changes
 
-- Add `ixquick` as a valid engine to `search_site()`. (#6)
+- Append `r programming` to major search engines by default (#11, #10)
+- Add `ixquick` as a valid engine to `search_site()`. (#8, #6)
 - Included link to repository and bug tracker to `DESCRIPTION`.
 
 # searcher 0.0.2

--- a/R/search-functions.R
+++ b/R/search-functions.R
@@ -85,8 +85,7 @@ search_site = function(query,
     duckduckgo     = ,
     # empty case carried below
     ddg            = search_duckduckgo(query, rlang),
-    ixquick        = search_ixquick(query, rlang),
-    search_google(query)
+    ixquick        = search_ixquick(query, rlang)
   )
 }
 

--- a/R/search-functions.R
+++ b/R/search-functions.R
@@ -71,7 +71,7 @@ search_site = function(query,
 
   switch(
     site,
-    google         = search_google(query),
+    google         = search_google(query, rlang),
     stackoverflow  = ,
     # empty case carried below
     so             = search_stackoverflow(query, rlang),
@@ -81,11 +81,11 @@ search_site = function(query,
     bitbucket      = ,
     # empty case carried below
     bb             = search_bitbucket(query, rlang),
-    bing           = search_bing(query),
+    bing           = search_bing(query, rlang),
     duckduckgo     = ,
     # empty case carried below
-    ddg            = search_duckduckgo(query),
-    ixquick        = search_ixquick(query),
+    ddg            = search_duckduckgo(query, rlang),
+    ixquick        = search_ixquick(query, rlang),
     search_google(query)
   )
 }
@@ -131,7 +131,7 @@ searcher = function(site  = c(
   "ixquick"
 ),
 rlang = TRUE) {
-  function(query = geterrmessage()) {
+  function(query = geterrmessage(), rlang = rlang) {
     search_site(query, site, rlang = rlang)
   }
 }
@@ -147,11 +147,13 @@ rlang = TRUE) {
 #'
 #' See \url{https://moz.com/blog/the-ultimate-guide-to-the-google-search-parameters}
 #' for details.
-search_google = function(query = geterrmessage()) {
+search_google = function(query = geterrmessage(), rlang = TRUE) {
   if (!valid_query(query)) {
     message("Please provide only 1 `query` term that is not empty.")
     return(invisible(""))
   }
+
+  query = append_r_suffix(query, rlang = rlang)
 
   browse_url("https://google.com/search?q=", query)
 }
@@ -161,11 +163,13 @@ search_google = function(query = geterrmessage()) {
 #' @section Bing Search:
 #' The `search_bing()` function searches [Bing](https://bing.com) using:
 #' `https://bing.com/search?q=<query>`
-search_bing = function(query = geterrmessage()) {
+search_bing = function(query = geterrmessage(), rlang = TRUE) {
   if (!valid_query(query)) {
     message("Please provide only 1 `query` term that is not empty.")
     return(invisible(""))
   }
+
+  query = append_r_suffix(query, rlang = rlang)
 
   browse_url("https://bing.com/search?q=", query)
 }
@@ -175,11 +179,13 @@ search_bing = function(query = geterrmessage()) {
 #' @section DuckDuckGo Search:
 #' The `search_duckduckgo()` and `search_ddg()` functions both search
 #' [DuckDuckGo](https://duckduckgo.com) using: `https://duckduckgo.com/?q=<query>`
-search_duckduckgo = function(query = geterrmessage()) {
+search_duckduckgo = function(query = geterrmessage(), rlang = TRUE) {
   if (!valid_query(query)) {
     message("Please provide only 1 `query` term that is not empty.")
     return(invisible(""))
   }
+
+  query = append_r_suffix(query, rlang = rlang)
 
   browse_url("https://duckduckgo.com/?q=", query)
 }
@@ -199,11 +205,13 @@ search_ddg = search_duckduckgo
 #' For additional details regarding [ixquick](https://ixquick.com)'s
 #' search interface please see:
 #'  \url{https://support.ixquick.com/index.php?/Knowledgebase/Article/View/201/0/how-do-i-make-startpage-by-ixquick-my-default-search-engine-in-chrome}
-search_ixquick = function(query = geterrmessage()) {
+search_ixquick = function(query = geterrmessage(), rlang = TRUE) {
   if (!valid_query(query)) {
     message("Please provide only 1 `query` term that is not empty.")
     return(invisible(""))
   }
+
+  query = append_r_suffix(query, rlang = rlang)
 
   browse_url("https://ixquick.com/do/dsearch?query=", query)
 }
@@ -229,10 +237,8 @@ search_stackoverflow = function(query = geterrmessage(), rlang = TRUE) {
     return(invisible(""))
   }
 
-  query = if (rlang)
-    paste(query, "[r]")
-  else
-    query
+  query = append_r_suffix(query, rlang = rlang, "[r]")
+
   browse_url("https://stackoverflow.com/search?q=", query)
 }
 
@@ -257,10 +263,7 @@ search_github = function(query = geterrmessage(), rlang = TRUE) {
     return(invisible(""))
   }
 
-  query = if (rlang)
-    paste(query, "language:r type:issue")
-  else
-    query
+  query = append_r_suffix(query, rlang = rlang, "language:r type:issue")
 
   browse_url("https://github.com/search?q=", query, "&type=Issues")
 }
@@ -286,10 +289,8 @@ search_bitbucket = function(query = geterrmessage(), rlang = TRUE) {
     return(invisible(""))
   }
 
-  query = if (rlang)
-    paste(query, "lang:r")
-  else
-    query
+  query = append_r_suffix(query, rlang = rlang, "lang:r")
+
   browse_url("https://bitbucket.com/search?q=", query)
 }
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -70,3 +70,30 @@ valid_query = function(query) {
     TRUE
   }
 }
+
+
+#' Append R Search Term Suffix
+#'
+#' Customizes the query string with an appropriate _R_ specific suffix.
+#'
+#' @param query  Search terms to verify
+#' @param rlang  Append value to query.
+#' @param suffix Value to be added to search query. Default `r programming`.
+#'
+#' @return Query string returned as-is or modified with a suffix that
+#' ensure results are _R_ oriented.
+#'
+#' @examples
+#'
+#' # Add suffix
+#' append_r_suffix("testing", rlang = TRUE, suffix = "toad")
+#'
+#' # Retain original search query
+#' append_r_suffix("testing", rlang = FALSE, suffix = "toad")
+#' @noRd
+append_r_suffix = function(query, rlang = TRUE, suffix = "r programming") {
+  if (rlang)
+    paste(query, suffix)
+  else
+    query
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -53,12 +53,16 @@ library(searcher)
 
 The `search_*()` functions can be used to search a query directly from _R_ on
 major search engines, code repositories, and help websites. The following search
-platforms are supported: Google, Bing, DuckDuckGo, StackOverflow, GitHub, and BitBucket.
+platforms are supported: Google, Bing, ixquick, DuckDuckGo, StackOverflow, GitHub,
+and BitBucket. By default, an appropriate suffix for each platform that ensures
+relevant results to _R_ is appended to all queries. This behavior can be 
+disabled by using `rlang = FALSE`.
 
 ```r
 # Searching R project on major search engines
 search_google("R project")
 search_bing("R project")
+search_ixquick("R project")
 search_duckduckgo("R project")                           # or search_ddg(...)
 
 # Searching for linear regression questions for R and in general

--- a/README.md
+++ b/README.md
@@ -47,13 +47,17 @@ library(searcher)
 
 The `search_*()` functions can be used to search a query directly from
 *R* on major search engines, code repositories, and help websites. The
-following search platforms are supported: Google, Bing, DuckDuckGo,
-StackOverflow, GitHub, and BitBucket.
+following search platforms are supported: Google, Bing, ixquick,
+DuckDuckGo, StackOverflow, GitHub, and BitBucket. By default, an
+appropriate suffix for each platform that ensures relevant results to
+*R* is appended to all queries. This behavior can be disabled by using
+`rlang = FALSE`.
 
 ``` r
 # Searching R project on major search engines
 search_google("R project")
 search_bing("R project")
+search_ixquick("R project")
 search_duckduckgo("R project")                           # or search_ddg(...)
 
 # Searching for linear regression questions for R and in general

--- a/man/search_site.Rd
+++ b/man/search_site.Rd
@@ -18,15 +18,15 @@
 search_site(query, site = c("google", "bing", "stackoverflow", "so", "github",
   "gh", "duckduckgo", "ddg", "bitbucket", "bb", "ixquick"), rlang = TRUE)
 
-search_google(query = geterrmessage())
+search_google(query = geterrmessage(), rlang = TRUE)
 
-search_bing(query = geterrmessage())
+search_bing(query = geterrmessage(), rlang = TRUE)
 
-search_duckduckgo(query = geterrmessage())
+search_duckduckgo(query = geterrmessage(), rlang = TRUE)
 
-search_ddg(query = geterrmessage())
+search_ddg(query = geterrmessage(), rlang = TRUE)
 
-search_ixquick(query = geterrmessage())
+search_ixquick(query = geterrmessage(), rlang = TRUE)
 
 search_stackoverflow(query = geterrmessage(), rlang = TRUE)
 

--- a/man/searcher-package.Rd
+++ b/man/searcher-package.Rd
@@ -7,7 +7,7 @@
 \title{searcher: Query Search Interfaces}
 \description{
 Provides a search interface to look up terms
-on 'Google', 'Bing', 'DuckDuckGo', 'StackOverflow', 'GitHub', and 'BitBucket'.
+on 'Google', 'Bing', 'ixquick', 'DuckDuckGo', 'StackOverflow', 'GitHub', and 'BitBucket'.
 Upon searching, a browser window will open with the aforementioned search
 results.
 }

--- a/tests/testthat/test-searcher.R
+++ b/tests/testthat/test-searcher.R
@@ -95,12 +95,46 @@ test_that("Validate selection", {
     "https://bitbucket.com/search?q=toad"
   )
 
+  expect_error(
+    search_site("toad", "", rlang = FALSE)
+  )
+
+  expect_identical(
+    search_site("toad", "ixquick", rlang = FALSE),
+    "https://ixquick.com/do/dsearch?query=toad"
+  )
+
+  expect_identical(
+    search_site("toad", "bing", rlang = FALSE),
+    "https://bing.com/search?q=toad"
+  )
+
+  expect_identical(
+    search_site("toad", "ddg", rlang = FALSE),
+    "https://duckduckgo.com/?q=toad"
+  )
+
   expect_identical(
     search_site("", rlang = FALSE),
     "",
     "Verify empty query fall through"
   )
 
+})
+
+
+
+
+test_that("Verify search handler generation", {
+  expect_identical(
+    searcher("bing", rlang = TRUE)(""),
+    search_bing("")
+  )
+
+  expect_identical(
+    searcher("bing", rlang = FALSE)(""),
+    search_bing("", rlang = FALSE)
+  )
 })
 
 

--- a/tests/testthat/test-searcher.R
+++ b/tests/testthat/test-searcher.R
@@ -6,6 +6,11 @@ test_that("Check link generation", {
 
   expect_identical(
     search_google("toad"),
+    "https://google.com/search?q=toad%20r%20programming"
+  )
+
+  expect_identical(
+    search_google("toad", rlang = FALSE),
     "https://google.com/search?q=toad"
   )
 
@@ -13,6 +18,11 @@ test_that("Check link generation", {
 
   expect_identical(
     search_bing("toad"),
+    "https://bing.com/search?q=toad%20r%20programming"
+  )
+
+  expect_identical(
+    search_bing("toad", rlang = FALSE),
     "https://bing.com/search?q=toad"
   )
 
@@ -20,6 +30,11 @@ test_that("Check link generation", {
 
   expect_identical(
     search_duckduckgo("toad"),
+    "https://duckduckgo.com/?q=toad%20r%20programming"
+  )
+
+  expect_identical(
+    search_duckduckgo("toad", rlang = FALSE),
     "https://duckduckgo.com/?q=toad"
   )
 
@@ -27,6 +42,11 @@ test_that("Check link generation", {
 
   expect_identical(
     search_ixquick("toad"),
+    "https://ixquick.com/do/dsearch?query=toad%20r%20programming"
+  )
+
+  expect_identical(
+    search_ixquick("toad", rlang = FALSE),
     "https://ixquick.com/do/dsearch?query=toad"
   )
 


### PR DESCRIPTION
Related to the `plot` issue raised by @jonocarroll in #10 